### PR TITLE
Add missing newline between bullet points

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -27,6 +27,7 @@ The check_illiad_emails plugin supports monitoring Pending email
 notifications:
 
 • greater number queued than specified
+
 • that have remained "in the queue" for longer than a specified amount of time
 
 Default values are provided, but are easily overridden with custom values in


### PR DESCRIPTION
Without it, the entries are mashed together into a single line when viewed via pkg.go.dev.