### PR TITLE
Apply Go 1.19 specific doc comments linting fixes

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -6,36 +6,34 @@
 // full license information.
 
 /*
-
 Go-based tooling to check/verify an ILLiad server instance.
 
-PROJECT HOME
+# PROJECT HOME
 
 See our GitHub repo (https://github.com/atc0005/check-illiad) for the latest
 code, to file an issue or submit improvements for review and potential
 inclusion into the project.
 
-PURPOSE
+# PURPOSE
 
 This repo is intended to provide Nagios plugins that may be used to monitor an
 ILLiad instance. As of this writing, a plugin named check_illiad_emails is
 available that may be used to monitor email notifications.
 
-FEATURES
+# FEATURES
 
 The check_illiad_emails plugin supports monitoring Pending email
 notifications:
 
-• greater number queued than specified
-
-• that have remained "in the queue" for longer than a specified amount of time
+  - greater number queued than specified
+  - that have remained "in the queue" for longer than a specified amount of
+    time
 
 Default values are provided, but are easily overridden with custom values in
 order to match usage patterns for each instance.
 
-USAGE
+# USAGE
 
 See our main README for supported settings and examples.
-
 */
 package main


### PR DESCRIPTION
These changes are effectively a NOOP for earlier Go versions, but improve the formatting of rendered documentation.