### PR TITLE
Add missing cmd doc file

### DIFF
--- a/cmd/check_illiad_emails/doc.go
+++ b/cmd/check_illiad_emails/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-illiad
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// A Nagios plugin named check_illiad_emails that may be used to monitor email
+// notifications for an ILLiad instance.
+//
+// See our [GitHub repo]:
+//
+//   - to review documentation (including examples)
+//   - for the latest code
+//   - to file an issue or submit improvements for review and potential
+//     inclusion into the project
+//
+// [GitHub repo]: https://github.com/atc0005/check-illiad
+package main


### PR DESCRIPTION
Add "package" doc file to resolve revive `package-comment` linting error surfaced by recent linter update.