### PR TITLE
Fix Makefile Go module base path detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ WHAT 					= check_illiad_emails
 # work as intended.
 #
 # What package holds the "version" variable used in branding/version output?
-# VERSION_VAR_PKG			= $(shell go list .)
-VERSION_VAR_PKG			= $(shell go list .)/internal/config
+# VERSION_VAR_PKG			= $(shell go list -m)
+VERSION_VAR_PKG			= $(shell go list -m)/internal/config
 # VERSION_VAR_PKG			= main
 
 OUTPUTDIR 				= release_assets


### PR DESCRIPTION
Replace `go list .` with `go list -m` to reflect that most projects now no longer contain a doc.go file in the project root.

This change fixes the broken version "stamping" that the Makefile applies at project build time.

refs https://github.com/atc0005/todo/issues/46