### PR TITLE
Use UNKNOWN state for invalid command-line args

### DIFF
--- a/cmd/check_illiad_emails/main.go
+++ b/cmd/check_illiad_emails/main.go
@@ -33,10 +33,10 @@ func main() {
 		log.Err(configErr).Msg("error validating configuration")
 
 		plugin.AddError(configErr)
-		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
 		plugin.ServiceOutput = fmt.Sprintf(
 			"%s: Failed to load configuration: %v",
-			nagios.StateCRITICALLabel,
+			nagios.StateUNKNOWNLabel,
 			configErr,
 		)
 


### PR DESCRIPTION
Update handling of invalid flags/values to use an UNKNOWN exit state to comply with Nagios Plugin Guideline
recommendations.

refs atc0005/check-illiad#159
refs atc0005/todo#55
refs https://nagios-plugins.org/doc/guidelines.html