### PR TITLE
Use CRITICAL state for connection failures

### DIFF
--- a/cmd/check_illiad_emails/main.go
+++ b/cmd/check_illiad_emails/main.go
@@ -110,10 +110,10 @@ func main() {
 		plugin.AddError(dbOpenErr)
 		plugin.ServiceOutput = fmt.Sprintf(
 			"%s: Error connecting to %s",
-			nagios.StateUNKNOWNLabel,
+			nagios.StateCRITICALLabel,
 			cfg.DBServerHost(),
 		)
-		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		// no need to go any further, we *want* to exit right away; we don't
 		// have a connection to the remote server and there isn't anything
@@ -133,10 +133,10 @@ func main() {
 		cfg.Log.Error().Err(err).Msg("error verifying connection to server")
 
 		plugin.AddError(err)
-		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
 		plugin.ServiceOutput = fmt.Sprintf(
 			"%s: Failed to establish connection to database: %v",
-			nagios.StateUNKNOWNLabel,
+			nagios.StateCRITICALLabel,
 			err,
 		)
 


### PR DESCRIPTION
After further evaluation of Nagios Plugin Guideline recommendations and review of official plugin design, using a CRITICAL exit state appears to be the appropriate response for connection failures.

- refs atc0005/check-illiad#159
- refs atc0005/check-vmware#767
- refs atc0005/todo#55
- refs https://nagios-plugins.org/doc/guidelines.html#AEN78
- refs https://icinga.com/docs/icinga-2/latest/doc/05-service-monitoring/#status