### PR TITLE
Update project to Go 1.20 series

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -111,8 +111,8 @@ updates:
     ignore:
       - dependency-name: "golang"
         versions:
-          - ">= 1.20"
-          - "< 1.19"
+          - ">= 1.21"
+          - "< 1.20"
 
   - package-ecosystem: docker
     directory: "/dependabot/docker/go"

--- a/dependabot/docker/go/Dockerfile
+++ b/dependabot/docker/go/Dockerfile
@@ -15,4 +15,4 @@
 # binaries) to reflect that version of Go.
 
 # https://hub.docker.com/_/golang
-FROM golang:1.19.12
+FROM golang:1.20.6

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@
 
 module github.com/atc0005/check-illiad
 
-go 1.19
+go 1.20
 
 require (
 	github.com/alexflint/go-arg v1.4.3


### PR DESCRIPTION
- update Go module version from Go 1.19 to 1.20
- update Dependabot configuration for Dockerfile to ignore Go releases
  outside of the Go 1.20 release series
- update "Canary" Dockerfile to reflect one release back from latest
  release in Go 1.20 series
  - confirm that Dependabot configuration changes are working as
    intended
