### PR TITLE
Update Dependabot PR prefixes (redux)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,7 +67,7 @@ updates:
     allow:
       - dependency-type: "all"
     commit-message:
-      prefix: "ghaw"
+      prefix: "CI Dependency"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -85,7 +85,7 @@ updates:
     allow:
       - dependency-type: "all"
     commit-message:
-      prefix: "ghaw"
+      prefix: "CI Dependency"
 
   ######################################################################
   # Monitor Go updates to service as a reminder to generate new releases


### PR DESCRIPTION
Swap out current prefix for GitHub Actions updates for one which
provides better context for what the update covers.

- replace `ghaw` with `CI Dependency`

Refs:

- atc0005/todo#72