### PR TITLE
Fix govet linting errors raised by updated linter

### DIFF
--- a/cmd/check_illiad_emails/main.go
+++ b/cmd/check_illiad_emails/main.go
@@ -9,6 +9,7 @@ package main
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -365,7 +366,7 @@ func main() {
 				plugin.ExitStatusCode = nagios.StateWARNINGExitCode
 			}
 
-			plugin.AddError(fmt.Errorf(summaryMsg))
+			plugin.AddError(errors.New(summaryMsg))
 			plugin.ServiceOutput = fmt.Sprintf(
 				"%s: %s [CRITICAL: %v, WARNING: %v, total pending: %d]",
 				nagios.StateCRITICALLabel,


### PR DESCRIPTION
Surfaced by golangci-lint v1.60.1 (built with Go 1.23.0).